### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pyxel"
+run = ""

--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ pip3 install -r requirements.txt
 - Maze entrance and exit are randomly generated as well for each level.
 - Maze is guaranteed to have one and only path.
 - Sound effect is played when player reaches the exit in each level.
+[![Run on Repl.it](https://repl.it/badge/github/balloonio/maze-runner)](https://repl.it/github/balloonio/maze-runner)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@k2kennedyl/maze-runner-1).